### PR TITLE
Remove bundled demo archive and update quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Generated demo archives
+examples/hello_codehealer_target.zip
+examples/hello_codehealer_target_fixed.zip
+healed_repo/

--- a/examples/hello_codehealer/README.md
+++ b/examples/hello_codehealer/README.md
@@ -1,0 +1,15 @@
+# Hello CodeHealer Target Repo
+
+This tiny repository is designed to exercise the default CodeHealer workflow. It contains a
+single script, `app.py`, that prints a greeting. After the healer finishes running you can
+validate success by executing:
+
+```bash
+python app.py
+```
+
+Expected output:
+
+```
+Hello from the CodeHealer target repo!
+```

--- a/examples/hello_codehealer/app.py
+++ b/examples/hello_codehealer/app.py
@@ -1,0 +1,9 @@
+"""Example target repo for CodeHealer quickstart."""
+
+def main() -> None:
+    """Print the expected greeting for validation."""
+    print("Hello from the CodeHealer target repo!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- restyle the README with quickstart instructions and clearer architecture overview
- add a ready-to-use sample target repository for demonstrations
- document creating the demo zip on demand and stop tracking the binary archive

## Testing
- python examples/hello_codehealer/app.py
- pip install -e . *(fails in this environment because external package indexes are blocked by a proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f6acdecc8327aab7b8871aa2a5da