### PR TITLE
Add interactive tutorial notebook and comprehensive tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,28 @@
 examples/hello_codehealer_target.zip
 examples/hello_codehealer_target_fixed.zip
 healed_repo/
+
+# Python build artifacts and virtual environments
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.venv/
+venv/
+env/
+
+# Jupyter notebook and editor caches
+.ipynb_checkpoints/
+.ipynb_tracking/
+.DS_Store
+.idea/
+.vscode/
+Thumbs.db
+
+# Local sandbox environments created by CodeHealer
+.codehealer_venv/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ matches the intended behavior.
 
 ---
 
+## 📓 Interactive Examples
+Explore the end-to-end workflow inside Jupyter with the notebook at
+`examples/tutorials/codehealer_interactive_tutorial.ipynb`. It contains:
+
+- A **Quickstart** walk-through that mirrors the CLI workflow shown above.
+- A **deep dive** into the Environment and Code agents, with prompts you can adapt to your own repos.
+- An **extension sketch** that demonstrates how to subclass agents and plug them back into the Healer orchestrator.
+
+Launch it with Jupyter Lab or VS Code to experiment interactively:
+
+```bash
+pip install notebook
+jupyter lab examples/tutorials/codehealer_interactive_tutorial.ipynb
+```
+
+---
+
 ## 📂 Repository Layout
 ```
 .
@@ -86,6 +103,18 @@ matches the intended behavior.
 ├── Dockerfile               # Defines the codehealer-agent runtime image
 └── pyproject.toml           # Python package metadata (only depends on `openai`)
 ```
+
+---
+
+## ✅ Running the Test Suite
+Every core function is covered by unit tests. Install the development dependencies and run them with
+
+```bash
+pip install pytest
+pytest
+```
+
+The tests stub the OpenAI client, so they run quickly without network access.
 
 ---
 

--- a/codehealer/core/healer.py
+++ b/codehealer/core/healer.py
@@ -1,6 +1,6 @@
 import os
 import time
-from ..agents.env_agent import EnvironmentAgent
+from ..agents.environment_agent import EnvironmentAgent
 from ..agents.code_agent import CodeAgent
 from ..utils.runner import Runner
 from ..utils.file_handler import FileHandler

--- a/examples/tutorials/codehealer_interactive_tutorial.ipynb
+++ b/examples/tutorials/codehealer_interactive_tutorial.ipynb
@@ -1,0 +1,168 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# CodeHealer Interactive Tutorial\n",
+    "\n",
+    "This notebook walks you through a quickstart experience, a deep dive into the agents that power CodeHealer, and ideas for extending the tooling for your own automation needs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Quickstart: Heal a Repository in Minutes\n",
+    "\n",
+    "1. Point CodeHealer at the root of a Python repository.\n",
+    "2. Provide an OpenAI API key in your environment (`OPENAI_API_KEY`).\n",
+    "3. Launch the orchestrator to automatically repair dependency and runtime issues."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "quickstart"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from codehealer.core.healer import Healer\n",
+    "\n",
+    "# Replace this path with the project you want to heal.\n",
+    "target_repo_path = \"../some_python_project\"\n",
+    "\n",
+    "healer = Healer(repo_path=target_repo_path, max_iterations=5)\n",
+    "healer.heal()\n",
+    "\n",
+    "# The orchestrator will:\n",
+    "# 1. Create an isolated sandbox environment.\n",
+    "# 2. Install dependencies and repair requirements issues.\n",
+    "# 3. Run the app's entry point and automatically patch runtime errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Tip:** The sandbox is created *inside* the container, so your host environment remains untouched."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deep Dive: Understanding the Agents\n",
+    "\n",
+    "CodeHealer relies on two specialized agents built on top of OpenAI models:\n",
+    "\n",
+    "- **EnvironmentAgent**: Repairs `requirements.txt` files when `pip install` fails.\n",
+    "- **CodeAgent**: Analyses Python tracebacks and returns a fully patched source file.\n",
+    "\n",
+    "You can inspect and even subclass these agents to add guardrails or telemetry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "agents"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from codehealer.agents.environment_agent import EnvironmentAgent\n",
+    "from codehealer.agents.code_agent import CodeAgent\n",
+    "\n",
+    "repo_path = \"../some_python_project\"\n",
+    "env_agent = EnvironmentAgent(repo_path)\n",
+    "code_agent = CodeAgent(repo_path)\n",
+    "\n",
+    "pip_error_log = \"Collect the pip stderr here...\"\n",
+    "requirements_text = open(f\"{repo_path}/requirements.txt\", encoding=\"utf-8\").read()\n",
+    "\n",
+    "suggested_requirements = env_agent.get_suggestion(pip_error_log, requirements_text)\n",
+    "print(suggested_requirements)\n",
+    "\n",
+    "python_traceback = \"Traceback (most recent call last): ...\"\n",
+    "file_path, patched_code = code_agent.get_suggestion(python_traceback)\n",
+    "print(\"Patched file:\", file_path)\n",
+    "print(patched_code[:400], \"...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extending the Architecture\n",
+    "\n",
+    "CodeHealer is intentionally modular. You can replace agents, customize sandbox creation, or add new healing phases. Below is a sketch of how to introduce a custom agent that adds logging around code fixes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "extension"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from codehealer.agents.code_agent import CodeAgent\n",
+    "\n",
+    "class AuditedCodeAgent(CodeAgent):\n",
+    "    \"\"\"Wraps CodeAgent to persist every suggestion for review.\"\"\"\n",
+    "\n",
+    "    def __init__(self, repo_path, audit_log_path):\n",
+    "        super().__init__(repo_path)\n",
+    "        self.audit_log_path = audit_log_path\n",
+    "\n",
+    "    def get_suggestion(self, traceback_log):\n",
+    "        suggestion = super().get_suggestion(traceback_log)\n",
+    "        if suggestion:\n",
+    "            file_path, new_content = suggestion\n",
+    "            with open(self.audit_log_path, \"a\", encoding=\"utf-8\") as audit_log:\n",
+    "                audit_log.write(f\"Patched {file_path}\\n\")\n",
+    "        return suggestion\n",
+    "\n",
+    "# Swap the agent inside the healer orchestrator.\n",
+    "from codehealer.core.healer import Healer\n",
+    "\n",
+    "healer = Healer(repo_path=target_repo_path)\n",
+    "healer.code_agent = AuditedCodeAgent(target_repo_path, \"./audit.log\")\n",
+    "healer.heal()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Further Ideas\n",
+    "\n",
+    "- Add a static-analysis phase before runtime execution.\n",
+    "- Persist structured telemetry (e.g., JSON logs) for observability.\n",
+    "- Swap the sandbox implementation to target remote containers or Docker Compose services.\n",
+    "\n",
+    "Feel free to duplicate this notebook and adapt the examples for your own workflows!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class DummyOpenAIResponse:
+    def __init__(self, content):
+        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=content))]
+
+
+class DummyChatCompletions:
+    def __init__(self, outer):
+        self.outer = outer
+        self.last_kwargs = None
+
+    def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        if self.outer.raise_error:
+            raise self.outer.raise_error
+        return DummyOpenAIResponse(self.outer.response_content)
+
+
+class DummyChat:
+    def __init__(self, outer):
+        self.completions = DummyChatCompletions(outer)
+
+
+class DummyOpenAI:
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.response_content = ""
+        self.raise_error: Exception | None = None
+        self.chat = DummyChat(self)
+
+
+STUB_MODULE = types.ModuleType("openai")
+STUB_MODULE.OpenAI = DummyOpenAI
+sys.modules.setdefault("openai", STUB_MODULE)
+
+
+@pytest.fixture
+def temp_repo(tmp_path):
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    return repo_path
+
+
+@pytest.fixture(autouse=True)
+def ensure_api_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    yield
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -1,0 +1,22 @@
+import pytest
+
+from codehealer.agents.base_agent import BaseAgent
+
+
+def test_base_agent_init_requires_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        BaseAgent(repo_path="/tmp", system_prompt="test")
+
+
+def test_query_llm_returns_content():
+    agent = BaseAgent(repo_path="/tmp", system_prompt="system")
+    agent.client.response_content = "hello world"
+    response = agent._query_llm("user prompt")
+    assert response == "hello world"
+
+
+def test_query_llm_handles_errors():
+    agent = BaseAgent(repo_path="/tmp", system_prompt="system")
+    agent.client.raise_error = RuntimeError("boom")
+    assert agent._query_llm("user prompt") == ""

--- a/tests/test_code_agent.py
+++ b/tests/test_code_agent.py
@@ -1,0 +1,31 @@
+import os
+
+import pytest
+
+from codehealer.agents.code_agent import CodeAgent
+
+
+def test_code_agent_parses_valid_response(tmp_path):
+    repo_path = tmp_path
+    agent = CodeAgent(str(repo_path))
+    expected_file = repo_path / "module.py"
+    agent.client.response_content = (
+        "FILEPATH: module.py\n" "```python\nprint('hello')\n```"
+    )
+    suggestion = agent.get_suggestion("Traceback")
+    assert suggestion == (os.path.normpath(str(expected_file)), "print('hello')")
+
+
+def test_code_agent_rejects_invalid_format():
+    agent = CodeAgent("/tmp")
+    agent.client.response_content = "unexpected"
+    assert agent.get_suggestion("Traceback") is None
+
+
+def test_parse_response_rejects_outside_repo(tmp_path, capsys):
+    repo_path = tmp_path
+    agent = CodeAgent(str(repo_path))
+    response = "FILEPATH: ../secrets.py\n```python\nprint('hi')\n```"
+    assert agent._parse_response(response) is None
+    captured = capsys.readouterr()
+    assert "outside the repository" in captured.out

--- a/tests/test_environment_agent.py
+++ b/tests/test_environment_agent.py
@@ -1,0 +1,8 @@
+from codehealer.agents.environment_agent import EnvironmentAgent
+
+
+def test_environment_agent_returns_str(temp_repo):
+    agent = EnvironmentAgent(str(temp_repo))
+    agent.client.response_content = "flask==2.3.2"
+    suggestion = agent.get_suggestion("error log", "flask==0.1")
+    assert suggestion == "flask==2.3.2"

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -1,0 +1,16 @@
+from codehealer.utils.file_handler import FileHandler
+
+
+def test_write_and_read_file(tmp_path):
+    handler = FileHandler()
+    target = tmp_path / "sample.txt"
+    handler.write_file(target, "hello")
+    assert handler.read_file(target) == "hello"
+
+
+def test_read_file_handles_missing(tmp_path, capsys):
+    handler = FileHandler()
+    missing = tmp_path / "missing.txt"
+    assert handler.read_file(missing) is None
+    captured = capsys.readouterr()
+    assert "Error reading file" in captured.out

--- a/tests/test_healer.py
+++ b/tests/test_healer.py
@@ -1,0 +1,155 @@
+import pytest
+
+from codehealer.core.healer import Healer
+
+
+class StubSandbox:
+    def __init__(self):
+        self.created = False
+        self.cleaned = False
+
+    def create(self):
+        self.created = True
+
+    def cleanup(self):
+        self.cleaned = True
+
+
+class StubRunner:
+    def __init__(self):
+        self.requirements = None
+        self.install_attempts = []
+        self.run_attempts = []
+        self.entry_point = None
+        self.install_index = 0
+        self.run_index = 0
+
+    def find_requirements(self):
+        return self.requirements
+
+    def install_dependencies(self):
+        result = self.install_attempts[self.install_index]
+        self.install_index += 1
+        return result
+
+    def find_entry_point(self):
+        return self.entry_point
+
+    def run_entry_point(self, entry_point):
+        result = self.run_attempts[self.run_index]
+        self.run_index += 1
+        return result
+
+    def reset(self):
+        self.install_index = 0
+        self.run_index = 0
+
+
+class StubFileHandler:
+    def __init__(self):
+        self.read_calls = []
+        self.write_calls = []
+        self.content = {}
+
+    def read_file(self, path):
+        self.read_calls.append(path)
+        return self.content.get(path, "")
+
+    def write_file(self, path, content):
+        self.write_calls.append((path, content))
+        self.content[path] = content
+
+
+class StubEnvAgent:
+    def __init__(self):
+        self.suggestions = []
+
+    def get_suggestion(self, log, original):
+        return self.suggestions.pop(0) if self.suggestions else None
+
+
+class StubCodeAgent:
+    def __init__(self):
+        self.suggestions = []
+
+    def get_suggestion(self, log):
+        return self.suggestions.pop(0) if self.suggestions else None
+
+
+@pytest.fixture
+def healer(tmp_path, monkeypatch):
+    instance = Healer(str(tmp_path), max_iterations=4)
+    stub_runner = StubRunner()
+    instance.sandbox = StubSandbox()
+    instance.runner = stub_runner
+    instance.file_handler = StubFileHandler()
+    instance.env_agent = StubEnvAgent()
+    instance.code_agent = StubCodeAgent()
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    return instance
+
+
+def test_heal_success_path(healer):
+    healer.runner.requirements = None
+    healer.runner.entry_point = None
+
+    healer.heal()
+
+    assert healer.sandbox.created is True
+    assert healer.sandbox.cleaned is True
+
+
+def test_heal_environment_with_requirements_success(healer, tmp_path):
+    req_path = str(tmp_path / "requirements.txt")
+    healer.runner.requirements = req_path
+    healer.file_handler.content[req_path] = "flask==0.1"
+    healer.runner.install_attempts = [
+        (1, "error"),
+        (0, "ok"),
+    ]
+    healer.runner.reset()
+    healer.env_agent.suggestions = ["flask==2.3.2"]
+
+    assert healer._heal_environment() is True
+    assert healer.file_handler.write_calls == [(req_path, "flask==2.3.2")]
+
+
+def test_heal_environment_fails_without_suggestion(healer, tmp_path):
+    req_path = str(tmp_path / "requirements.txt")
+    healer.runner.requirements = req_path
+    healer.file_handler.content[req_path] = "flask==0.1"
+    healer.runner.install_attempts = [
+        (1, "error"),
+    ]
+    healer.runner.reset()
+    healer.env_agent.suggestions = []
+
+    assert healer._heal_environment() is False
+
+
+def test_heal_runtime_success(healer, tmp_path):
+    file_to_patch = str(tmp_path / "app.py")
+    healer.runner.entry_point = "main.py"
+    healer.runner.run_attempts = [
+        (1, "traceback"),
+        (0, "ok"),
+    ]
+    healer.runner.reset()
+    healer.code_agent.suggestions = [(file_to_patch, "print('fixed')")]
+
+    assert healer._heal_runtime() is True
+    assert healer.file_handler.write_calls[-1] == (file_to_patch, "print('fixed')")
+
+
+def test_heal_runtime_no_entry_point(healer):
+    healer.runner.entry_point = None
+    assert healer._heal_runtime() is True
+
+
+def test_heal_runtime_failure_without_fix(healer):
+    healer.runner.entry_point = "main.py"
+    healer.runner.run_attempts = [(1, "traceback")]
+    healer.runner.reset()
+    healer.code_agent.suggestions = []
+
+    assert healer._heal_runtime() is False

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,114 @@
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from codehealer.utils.runner import Runner
+from codehealer.utils.sandbox import SandboxManager
+
+
+class DummySandbox(SandboxManager):
+    def __init__(self, repo_path):
+        super().__init__(repo_path)
+        self.python_path = "python"
+        self.pip_path = "pip"
+
+    def get_python_executable(self):
+        return self.python_path
+
+    def get_pip_executable(self):
+        return self.pip_path
+
+
+def test_run_command_success(monkeypatch, temp_repo):
+    sandbox = DummySandbox(str(temp_repo))
+    runner = Runner(str(temp_repo), sandbox)
+
+    def fake_run(command, cwd, capture_output, text, timeout):
+        assert command == ["python", "--version"]
+        return SimpleNamespace(returncode=0, stdout="Python", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    code, output = runner._run_command(["python", "--version"])
+    assert code == 0
+    assert "Python" in output
+
+
+def test_run_command_handles_exception(monkeypatch, temp_repo):
+    sandbox = DummySandbox(str(temp_repo))
+    runner = Runner(str(temp_repo), sandbox)
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="python", timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    code, output = runner._run_command(["python"])
+    assert code == -1
+    assert "Failed to execute" in output
+
+
+def test_find_requirements(temp_repo):
+    sandbox = DummySandbox(str(temp_repo))
+    runner = Runner(str(temp_repo), sandbox)
+    assert runner.find_requirements() is None
+
+    req = temp_repo / "requirements.txt"
+    req.write_text("flask", encoding="utf-8")
+    assert runner.find_requirements() == str(req)
+
+
+def test_install_dependencies_invokes_pip(monkeypatch, temp_repo):
+    sandbox = DummySandbox(str(temp_repo))
+    sandbox.pip_path = "pip3"
+    runner = Runner(str(temp_repo), sandbox)
+
+    req = temp_repo / "requirements.txt"
+    req.write_text("flask", encoding="utf-8")
+
+    called = {}
+
+    def fake_run_command(command):
+        called["command"] = command
+        return 0, "ok"
+
+    monkeypatch.setattr(runner, "_run_command", fake_run_command)
+    code, output = runner.install_dependencies()
+    assert code == 0
+    assert called["command"] == ["pip3", "install", "-r", str(req)]
+    assert output == "ok"
+
+
+def test_install_dependencies_when_missing_requirements(temp_repo):
+    sandbox = DummySandbox(str(temp_repo))
+    runner = Runner(str(temp_repo), sandbox)
+    code, output = runner.install_dependencies()
+    assert code == 0
+    assert "No requirements" in output
+
+
+def test_find_entry_point(temp_repo):
+    sandbox = DummySandbox(str(temp_repo))
+    runner = Runner(str(temp_repo), sandbox)
+    assert runner.find_entry_point() is None
+
+    entry = temp_repo / "main.py"
+    entry.write_text("print('hi')", encoding="utf-8")
+    assert runner.find_entry_point() == "main.py"
+
+
+def test_run_entry_point(temp_repo, monkeypatch):
+    sandbox = DummySandbox(str(temp_repo))
+    sandbox.python_path = "python3"
+    runner = Runner(str(temp_repo), sandbox)
+
+    called = {}
+
+    def fake_run_command(command):
+        called["command"] = command
+        return 0, "ran"
+
+    monkeypatch.setattr(runner, "_run_command", fake_run_command)
+    code, output = runner.run_entry_point("main.py")
+    assert code == 0
+    assert called["command"] == ["python3", "main.py"]
+    assert output == "ran"

--- a/tests/test_sandbox_manager.py
+++ b/tests/test_sandbox_manager.py
@@ -1,0 +1,51 @@
+import venv
+
+from codehealer.utils.sandbox import SandboxManager
+
+
+def test_create_invokes_venv_creation(monkeypatch, tmp_path):
+    repo = tmp_path
+    target = repo / ".codehealer_venv"
+    created = {}
+
+    def fake_cleanup(self):
+        created["cleanup_called"] = True
+
+    def fake_create(path, with_pip):
+        created["venv_path"] = path
+        created["with_pip"] = with_pip
+
+    manager = SandboxManager(str(repo))
+    target.mkdir()
+    monkeypatch.setattr(SandboxManager, "cleanup", fake_cleanup, raising=False)
+    monkeypatch.setattr(venv, "create", fake_create)
+
+    manager.create()
+
+    assert created["cleanup_called"]
+    assert created["venv_path"] == str(target)
+    assert created["with_pip"] is True
+
+
+def test_get_python_and_pip_paths(tmp_path, monkeypatch):
+    repo = tmp_path
+    manager = SandboxManager(str(repo), venv_name="venv")
+    base = repo / "venv"
+    expected_python = base / "bin" / "python"
+    expected_pip = base / "bin" / "pip"
+
+    monkeypatch.setattr("sys.platform", "linux", raising=False)
+
+    assert manager.get_python_executable() == str(expected_python)
+    assert manager.get_pip_executable() == str(expected_pip)
+
+
+def test_cleanup_removes_directory(tmp_path):
+    repo = tmp_path
+    manager = SandboxManager(str(repo), venv_name="venv")
+    target = repo / "venv"
+    target.mkdir()
+    (target / "file.txt").write_text("data", encoding="utf-8")
+
+    manager.cleanup()
+    assert not target.exists()


### PR DESCRIPTION
## Summary
- expand ignore rules to exclude notebook and environment artifacts from version control
- add an interactive tutorial notebook that covers quickstart usage, agent internals, and extension ideas
- introduce a pytest suite that stubs the OpenAI client and exercises every core component, fixing a bad EnvironmentAgent import on the way

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5f9d3e3b48327b0d816bede25e368