### PR TITLE
Add Python 3.9 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a slim, official Python image as the base
-FROM python:3.11-slim-bookworm
+FROM python:3.9-slim-bookworm
 
 # Set the working directory inside the container
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ repairs the code, and hands back a fixed archive—no manual debugging required.
 ## 🚀 Highlights
 - **Container-first safety** – All healing happens inside the `codehealer-agent` Docker image.
 - **Bring-your-own project** – Feed in any zipped Python repository and get a patched version back.
-- **Minimal host setup** – You only need Python 3.10+, Docker, and an OpenAI API key.
+- **Minimal host setup** – You only need Python 3.9+, Docker, and an OpenAI API key.
 - **Zip-in / Zip-out workflow** – Perfect for CI pipelines and reproducible fixes.
 
 ---
@@ -25,7 +25,7 @@ repairs the code, and hands back a fixed archive—no manual debugging required.
 
 ## 🛠️ Quickstart (6 steps)
 1. **Install prerequisites**
-   - Python 3.10 or newer
+   - Python 3.9 or newer
    - Docker Engine running locally
    - An `OPENAI_API_KEY`
 

--- a/codehealer/utils/file_handler.py
+++ b/codehealer/utils/file_handler.py
@@ -1,8 +1,10 @@
-import os
+from typing import Optional
+
 
 class FileHandler:
     """Handles reading from and writing to files."""
-    def read_file(self, file_path: str) -> str | None:
+
+    def read_file(self, file_path: str) -> Optional[str]:
         try:
             with open(file_path, 'r', encoding='utf-8') as f:
                 return f.read()

--- a/codehealer/utils/runner.py
+++ b/codehealer/utils/runner.py
@@ -1,6 +1,6 @@
 import subprocess
 import os
-from typing import List
+from typing import List, Optional
 from .sandbox import SandboxManager
 
 class Runner:
@@ -24,7 +24,7 @@ class Runner:
         except Exception as e:
             return -1, f"Failed to execute command '{' '.join(command)}': {e}"
 
-    def find_requirements(self) -> str | None:
+    def find_requirements(self) -> Optional[str]:
         path = os.path.join(self.repo_path, 'requirements.txt')
         return path if os.path.exists(path) else None
 
@@ -36,7 +36,7 @@ class Runner:
         pip_exe = self.sandbox.get_pip_executable()
         return self._run_command([pip_exe, "install", "-r", requirements_path])
 
-    def find_entry_point(self) -> str | None:
+    def find_entry_point(self) -> Optional[str]:
         common_files = ['main.py', 'app.py', 'run.py']
         for filename in common_files:
             path = os.path.join(self.repo_path, filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "codehealer"
 version = "2.1.0"
 description = "An autonomous agent to resolve environment and runtime errors in Python repos."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
     "openai",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import sys
 import types
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -36,7 +37,7 @@ class DummyOpenAI:
     def __init__(self, api_key: str):
         self.api_key = api_key
         self.response_content = ""
-        self.raise_error: Exception | None = None
+        self.raise_error: Optional[Exception] = None
         self.chat = DummyChat(self)
 
 


### PR DESCRIPTION
## Summary
- lower the minimum supported Python version to 3.9 in packaging, documentation, and the Docker image
- replace Python 3.10 union type annotations with typing.Optional to support 3.9 runtimes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5fc31610883279b6723c38afa578f