### PR TITLE
Handle optional base path in FileHandler

### DIFF
--- a/codehealer/utils/file_handler.py
+++ b/codehealer/utils/file_handler.py
@@ -1,26 +1,47 @@
 import os
 import difflib
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
+
 
 class FileHandler:
     """Handles reading from, writing to, and discovering files."""
 
-    def read_file(self, file_path: str) -> Optional[str]:
+    def __init__(self, base_path: Optional[Union[str, os.PathLike]] = None) -> None:
+        """Create a handler optionally tied to a repository root.
+
+        Historically the class was instantiated without any arguments.  Recent
+        callers (such as :class:`codehealer.agents.code_agent.CodeAgent`) expect
+        to be able to provide a repository path.  To remain backward compatible
+        we accept an optional ``base_path`` while keeping the zero-argument
+        constructor working for existing tests and code.
+        """
+
+        self.base_path = Path(base_path).resolve() if base_path is not None else None
+
+    def _normalize_path(self, file_path: Union[str, os.PathLike]) -> Path:
+        """Return a ``Path`` instance for ``file_path``."""
+
+        return Path(file_path)
+
+    def read_file(self, file_path: Union[str, os.PathLike]) -> Optional[str]:
         try:
-            with open(file_path, 'r', encoding='utf-8') as f:
+            path = self._normalize_path(file_path)
+            with path.open('r', encoding='utf-8') as f:
                 return f.read()
         except IOError as e:
             print(f"Error reading file {file_path}: {e}")
             return None
 
-    def write_file(self, file_path: str, content: str):
+    def write_file(self, file_path: Union[str, os.PathLike], content: str):
         """Writes content to a file and prints a colored diff of the changes."""
-        original_content = self.read_file(file_path) or ""
+        path = self._normalize_path(file_path)
+        original_content = self.read_file(path) or ""
         diff = "".join(difflib.unified_diff(
             original_content.splitlines(keepends=True),
             content.splitlines(keepends=True),
-            fromfile=f"a/{os.path.relpath(file_path)}",
-            tofile=f"b/{os.path.relpath(file_path)}"
+            fromfile=f"a/{os.path.relpath(path)}",
+            tofile=f"b/{os.path.relpath(path)}"
         ))
         
         # Color the diff for better readability
@@ -40,19 +61,37 @@ class FileHandler:
         print("[container] --- END DIFF ---")
         
         try:
-            with open(file_path, 'w', encoding='utf-8') as f:
+            with path.open('w', encoding='utf-8') as f:
                 f.write(content)
         except IOError as e:
             print(f"Error writing to file {file_path}: {e}")
 
-    def list_all_python_files(self, root_path: str) -> dict[str, str]:
-        """Lists all python files in a directory and returns a dict of relative_path: content."""
+    def list_all_python_files(self, root_path: Optional[Union[str, os.PathLike]] = None) -> dict[str, str]:
+        """Lists all python files in a directory.
+
+        Parameters
+        ----------
+        root_path:
+            Optional path to search.  When omitted we fall back to the
+            ``base_path`` provided at construction time.
+        """
+
+        search_root: Optional[Path]
+        if root_path is not None:
+            search_root = Path(root_path)
+        else:
+            search_root = self.base_path
+
+        if search_root is None:
+            raise ValueError("No root path provided for listing python files.")
+
+        search_root = search_root.resolve()
         py_files = {}
-        for root, _, files in os.walk(root_path):
+        for root, _, files in os.walk(search_root):
             for file in files:
                 if file.endswith(".py"):
-                    full_path = os.path.join(root, file)
-                    relative_path = os.path.relpath(full_path, root_path)
+                    full_path = Path(root) / file
+                    relative_path = os.path.relpath(full_path, search_root)
                     content = self.read_file(full_path)
                     if content:
                         py_files[relative_path] = content


### PR DESCRIPTION
## Summary
- allow `FileHandler` to accept an optional base path at construction
- support path-like objects throughout read/write operations and reuse stored base path when listing Python files

## Testing
- pytest *(fails: known import/module availability issues in existing example and target repos)*
- python main.py --dir target_repo/respiratory_monitor-main/breathing_monitor *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d71b4d97f883279b2919decb59767b